### PR TITLE
Meilisearch as peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ This package is a simple wrapper around [meilisearch-js](https://github.com/meil
 
 ## Installation
 
+This package requires `meilisearch` dependency to work properly.
+
 ```bash
-yarn add nestjs-meilisearch
+yarn add nestjs-meilisearch meilisearch
 ```
 
 ## Getting Started

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-meilisearch",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Meilisearch integration for nestjs.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -26,13 +26,14 @@
   },
   "license": "MIT",
   "private": false,
-  "dependencies": {
-    "@nestjs/common": "^8.0.7",
-    "meilisearch": "^0.20.2",
+  "peerDependencies": {
+    "@nestjs/common": "^6.0.0 || ^7.0.0 || ^8.0.0",
+    "meilisearch": ">=0.10.0 <1.0.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.3.0"
+    "rxjs": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
+    "@nestjs/common": "^8.0.7",
     "@nestjs/core": "^8.0.7",
     "@nestjs/testing": "^8.0.7",
     "@types/jest": "^27.0.2",
@@ -44,8 +45,11 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.2.2",
+    "meilisearch": "^0.20.2",
     "prettier": "^2.4.1",
+    "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
+    "rxjs": "^7.3.0",
     "supertest": "^6.1.6",
     "ts-jest": "^27.0.5",
     "ts-loader": "^9.2.6",


### PR DESCRIPTION
- Change `dependencies` to be `peerDependencies`
- Add previous `dependencies` to the `devDependencies` section
- Allow installation of `meilisearch` from version `0.10.0` up to `1.0.0`
- Update installation section of documentation
- Bump package version to `2.1.0`

See #2 