### PR TITLE
fix: use provided options in forRoot

### DIFF
--- a/src/meilisearch.module.ts
+++ b/src/meilisearch.module.ts
@@ -15,11 +15,7 @@ export class MeiliSearchModule {
 
     const connectionProvider: Provider = {
       provide: MEILI_CLIENT,
-      useFactory: async () =>
-        await createConnectionFactory({
-          host: 'http://127.0.0.1:7700',
-          apiKey: '12131211',
-        }),
+      useFactory: async () => await createConnectionFactory(options),
     };
     return {
       module: MeiliSearchModule,


### PR DESCRIPTION
This PR replaces the test code in `.forRoot` by the provided options.

Before, no matter the api key we gave in options it would not work, unless it was, of course, `12131211`.
This patch makes it so we connect with the user-provided options and their own host/api key, the same way it is done in `forRootAsync`