### PR TITLE
chore(deps): bump `reflect-metadata` to `0.2.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@nestjs/common": "^10.0.0",
     "meilisearch": ">=0.31.1 <1.0.0",
-    "reflect-metadata": "^0.1.13",
+    "reflect-metadata": "^0.1.13 || ^0.2.1",
     "rxjs": "^6.0.0 || ^7.8.0"
   },
   "devDependencies": {
@@ -48,7 +48,7 @@
     "jest": "^29.4.3",
     "meilisearch": "^0.31.1",
     "prettier": "^2.8.4",
-    "reflect-metadata": "^0.1.13",
+    "reflect-metadata": "^0.2.1",
     "rimraf": "^4.3.0",
     "rxjs": "^7.8.0",
     "supertest": "^6.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3056,10 +3056,10 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-reflect-metadata@^0.1.13:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
-  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
+reflect-metadata@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz#400c845b6cba87a21f2c65c4aeb158f4fa4d9c5b"
+  integrity sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==
 
 regexpp@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
This PR seeks to allow `v0.2.x` for `reflect-metadata` to be used alongside this package as a peer dependency.