### PR TITLE
fix(github): add build step before publishing release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,14 @@ jobs:
 
       - run: pnpm dlx changelogithub
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
 
       - name: Build library
         run: pnpm build
 
       - run: pnpm publish --no-git-checks
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Fixes #13 

---

### Summary

- [x] Install dependencies from lockfile in CI/CD to ensure consistency when publishing; we should only be modifying lock files in development imo.
- [x] Add build step before publishing